### PR TITLE
change references to @csiro/ecl-builder to version 0.2.1, remove .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-@csiro:registry=https://pkgs.dev.azure.com/aehrc/ontoserver/_packaging/aehrc-npm/npm/registry/
-         
-always-auth=true

--- a/apps/ecl-builder-app/package.json
+++ b/apps/ecl-builder-app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@csiro/ecl-builder": "^0.2.1",
+    "ecl-builder": "^0.2.1",
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
     "@mui/material": "^5.8.3",

--- a/apps/ecl-builder-app/package.json
+++ b/apps/ecl-builder-app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@csiro/ecl-builder": "^0.1.2",
+    "@csiro/ecl-builder": "^0.2.1",
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
     "@mui/material": "^5.8.3",

--- a/apps/ecl-builder-app/src/App.tsx
+++ b/apps/ecl-builder-app/src/App.tsx
@@ -1,6 +1,6 @@
 import { Box, createTheme, CssBaseline, ThemeProvider } from "@mui/material";
-import ExpressionBuilder from "@csiro/ecl-builder";
-import ExpressionResult from "@csiro/ecl-builder/lib/components/ExpressionResult";
+import ExpressionBuilder from "ecl-builder";
+import ExpressionResult from "ecl-builder/lib/components/ExpressionResult";
 import React, { useState } from "react";
 
 let theme = createTheme();

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
     "apps/ecl-builder-app": {
       "version": "0.1.0",
       "dependencies": {
-        "@csiro/ecl-builder": "^0.1.2",
+        "@csiro/ecl-builder": "^0.2.1",
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",
         "@mui/icons-material": "^5.8.3",
@@ -31370,8 +31370,8 @@
     },
     "packages/ecl-builder": {
       "name": "@csiro/ecl-builder",
-      "version": "0.1.8",
-      "license": "UNLICENSED",
+      "version": "0.2.1",
+      "license": "Apache-2.0",
       "dependencies": {
         "@tanstack/react-query": "^4.2.1",
         "@types/antlr4": "^4.7.2",
@@ -43650,7 +43650,7 @@
     "ecl-builder-app": {
       "version": "file:apps/ecl-builder-app",
       "requires": {
-        "@csiro/ecl-builder": "^0.1.2",
+        "@csiro/ecl-builder": "^0.2.1",
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",
         "@mui/icons-material": "^5.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
     "apps/ecl-builder-app": {
       "version": "0.1.0",
       "dependencies": {
-        "@csiro/ecl-builder": "^0.2.1",
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",
         "@mui/icons-material": "^5.8.3",
@@ -20,6 +19,7 @@
         "@types/node": "^16.11.56",
         "@types/react": "^17.0.2",
         "@types/react-dom": "^17.0.2",
+        "ecl-builder": "^0.2.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-scripts": "5.0.1",
@@ -2203,10 +2203,6 @@
       "engines": {
         "node": ">=0.1.90"
       }
-    },
-    "node_modules/@csiro/ecl-builder": {
-      "resolved": "packages/ecl-builder",
-      "link": true
     },
     "node_modules/@csstools/normalize.css": {
       "version": "12.0.0",
@@ -15728,6 +15724,10 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/ecl-builder": {
+      "resolved": "packages/ecl-builder",
+      "link": true
     },
     "node_modules/ecl-builder-app": {
       "resolved": "apps/ecl-builder-app",
@@ -31369,7 +31369,6 @@
       }
     },
     "packages/ecl-builder": {
-      "name": "@csiro/ecl-builder",
       "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -33446,470 +33445,6 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true,
       "optional": true
-    },
-    "@csiro/ecl-builder": {
-      "version": "file:packages/ecl-builder",
-      "requires": {
-        "@babel/core": "^7.18.10",
-        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-        "@babel/preset-env": "^7.18.10",
-        "@babel/preset-typescript": "^7.18.6",
-        "@emotion/react": "^11.9.3",
-        "@emotion/styled": "^11.9.3",
-        "@mui/icons-material": "^5.8.4",
-        "@mui/material": "^5.8.6",
-        "@storybook/addon-actions": "^8.0.10",
-        "@storybook/addon-essentials": "^8.0.10",
-        "@storybook/addon-interactions": "^8.0.10",
-        "@storybook/addon-links": "^8.0.10",
-        "@storybook/addon-webpack5-compiler-swc": "^1.0.2",
-        "@storybook/core-common": "^8.0.10",
-        "@storybook/csf-tools": "^8.0.10",
-        "@storybook/react": "^8.0.10",
-        "@storybook/react-webpack5": "^8.0.10",
-        "@storybook/test": "^8.0.10",
-        "@tanstack/react-query": "^4.2.1",
-        "@types/antlr4": "^4.7.2",
-        "@types/fhir": "^0.0.35",
-        "@types/jest": "^28.1.7",
-        "@types/react": "^18.0.12",
-        "@types/react-copy-to-clipboard": "^5.0.4",
-        "@types/uuid": "^8.3.4",
-        "@typescript-eslint/eslint-plugin": "^5.33.1",
-        "@typescript-eslint/parser": "^5.33.1",
-        "antlr4": "~4.10.1",
-        "babel-jest": "^28.1.3",
-        "babel-loader": "^8.2.5",
-        "eslint": "^8.22.0",
-        "eslint-plugin-react": "^7.30.1",
-        "eslint-plugin-react-hooks": "^4.6.0",
-        "eslint-plugin-storybook": "^0.8.0",
-        "fix-tsc-es-imports": "^0.1.6",
-        "glob": "^10.3.14",
-        "jest": "^28.1.3",
-        "magicast": "^0.3.4",
-        "react": "^17.0.2",
-        "react-copy-to-clipboard": "^5.1.0",
-        "react-dom": "^17.0.2",
-        "storybook": "^8.0.10",
-        "typescript": "^4.7.3",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "@storybook/core-common": {
-          "version": "8.0.10",
-          "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-8.0.10.tgz",
-          "integrity": "sha512-hsFlPieputaDQoxstnPa3pykTc4bUwEDgCHf8U43+/Z7qmLOQ9fpG+2CFW930rsCRghYpPreOvsmhY7lsGKWLQ==",
-          "dev": true,
-          "requires": {
-            "@storybook/core-events": "8.0.10",
-            "@storybook/csf-tools": "8.0.10",
-            "@storybook/node-logger": "8.0.10",
-            "@storybook/types": "8.0.10",
-            "@yarnpkg/fslib": "2.10.3",
-            "@yarnpkg/libzip": "2.3.0",
-            "chalk": "^4.1.0",
-            "cross-spawn": "^7.0.3",
-            "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
-            "esbuild-register": "^3.5.0",
-            "execa": "^5.0.0",
-            "file-system-cache": "2.3.0",
-            "find-cache-dir": "^3.0.0",
-            "find-up": "^5.0.0",
-            "fs-extra": "^11.1.0",
-            "glob": "^10.0.0",
-            "handlebars": "^4.7.7",
-            "lazy-universal-dotenv": "^4.0.0",
-            "node-fetch": "^2.0.0",
-            "picomatch": "^2.3.0",
-            "pkg-dir": "^5.0.0",
-            "pretty-hrtime": "^1.0.3",
-            "resolve-from": "^5.0.0",
-            "semver": "^7.3.7",
-            "tempy": "^1.0.1",
-            "tiny-invariant": "^1.3.1",
-            "ts-dedent": "^2.0.0",
-            "util": "^0.12.4"
-          }
-        },
-        "@storybook/core-events": {
-          "version": "8.0.10",
-          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.0.10.tgz",
-          "integrity": "sha512-TuHPS6p5ZNr4vp4butLb4R98aFx0NRYCI/7VPhJEUH5rPiqNzE3PZd8DC8rnVxavsJ+jO1/y+egNKXRYkEcoPQ==",
-          "dev": true,
-          "requires": {
-            "ts-dedent": "^2.0.0"
-          }
-        },
-        "@storybook/node-logger": {
-          "version": "8.0.10",
-          "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.0.10.tgz",
-          "integrity": "sha512-UMmaUaA3VOX/mKLsSvOnbZre2/1tZ6hazA6H0eAnClKb51jRD1AJrsBYK+uHr/CAp7t710bB5U8apPov7hayDw==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "dotenv": {
-          "version": "16.4.5",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-          "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-          "dev": true
-        },
-        "dotenv-expand": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
-          "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
-          "dev": true
-        },
-        "eslint": {
-          "version": "8.22.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.22.0.tgz",
-          "integrity": "sha512-ci4t0sz6vSRKdmkOGmprBo6fmI4PrphDFMy5JEq/fNS0gQkJM3rLmrqcp8ipMcdobH3KtUP40KniAE9W19S4wA==",
-          "dev": true,
-          "requires": {
-            "@eslint/eslintrc": "^1.3.0",
-            "@humanwhocodes/config-array": "^0.10.4",
-            "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
-            "ajv": "^6.10.0",
-            "chalk": "^4.0.0",
-            "cross-spawn": "^7.0.2",
-            "debug": "^4.3.2",
-            "doctrine": "^3.0.0",
-            "escape-string-regexp": "^4.0.0",
-            "eslint-scope": "^7.1.1",
-            "eslint-utils": "^3.0.0",
-            "eslint-visitor-keys": "^3.3.0",
-            "espree": "^9.3.3",
-            "esquery": "^1.4.0",
-            "esutils": "^2.0.2",
-            "fast-deep-equal": "^3.1.3",
-            "file-entry-cache": "^6.0.1",
-            "find-up": "^5.0.0",
-            "functional-red-black-tree": "^1.0.1",
-            "glob-parent": "^6.0.1",
-            "globals": "^13.15.0",
-            "globby": "^11.1.0",
-            "grapheme-splitter": "^1.0.4",
-            "ignore": "^5.2.0",
-            "import-fresh": "^3.0.0",
-            "imurmurhash": "^0.1.4",
-            "is-glob": "^4.0.0",
-            "js-yaml": "^4.1.0",
-            "json-stable-stringify-without-jsonify": "^1.0.1",
-            "levn": "^0.4.1",
-            "lodash.merge": "^4.6.2",
-            "minimatch": "^3.1.2",
-            "natural-compare": "^1.4.0",
-            "optionator": "^0.9.1",
-            "regexpp": "^3.2.0",
-            "strip-ansi": "^6.0.1",
-            "strip-json-comments": "^3.1.0",
-            "text-table": "^0.2.0",
-            "v8-compile-cache": "^2.0.3"
-          }
-        },
-        "eslint-scope": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-          "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.3.0",
-            "estraverse": "^5.2.0"
-          }
-        },
-        "file-system-cache": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/file-system-cache/-/file-system-cache-2.3.0.tgz",
-          "integrity": "sha512-l4DMNdsIPsVnKrgEXbJwDJsA5mB8rGwHYERMgqQx/xAUtChPJMre1bXBzDEqqVbWv9AIbFezXMxeEkZDSrXUOQ==",
-          "dev": true,
-          "requires": {
-            "fs-extra": "11.1.1",
-            "ramda": "0.29.0"
-          },
-          "dependencies": {
-            "fs-extra": {
-              "version": "11.1.1",
-              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-              "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-              }
-            }
-          }
-        },
-        "find-cache-dir": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-          "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
-          "dev": true,
-          "requires": {
-            "commondir": "^1.0.1",
-            "make-dir": "^3.0.2",
-            "pkg-dir": "^4.1.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-              "dev": true,
-              "requires": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-              }
-            },
-            "pkg-dir": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-              "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-              "dev": true,
-              "requires": {
-                "find-up": "^4.0.0"
-              }
-            }
-          }
-        },
-        "fs-extra": {
-          "version": "11.2.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "glob": {
-          "version": "10.3.14",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.14.tgz",
-          "integrity": "sha512-4fkAqu93xe9Mk7le9v0y3VrPDqLKHarNi2s4Pv7f2yOvfhWfhc7hRPHC/JyqMqb8B/Dt/eGS4n7ykwf3fOsl8g==",
-          "dev": true,
-          "requires": {
-            "foreground-child": "^3.1.0",
-            "jackspeak": "^2.3.6",
-            "minimatch": "^9.0.1",
-            "minipass": "^7.0.4",
-            "path-scurry": "^1.11.0"
-          },
-          "dependencies": {
-            "minimatch": {
-              "version": "9.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-              "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^2.0.1"
-              }
-            }
-          }
-        },
-        "globals": {
-          "version": "13.17.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-          "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
-          "dev": true,
-          "requires": {
-            "type-fest": "^0.20.2"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "dev": true,
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        },
-        "lazy-universal-dotenv": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/lazy-universal-dotenv/-/lazy-universal-dotenv-4.0.0.tgz",
-          "integrity": "sha512-aXpZJRnTkpK6gQ/z4nk+ZBLd/Qdp118cvPruLSIQzQNRhKwEcdXCOzXuF55VDqIiuAaY3UGZ10DJtvZzDcvsxg==",
-          "dev": true,
-          "requires": {
-            "app-root-dir": "^1.0.2",
-            "dotenv": "^16.0.0",
-            "dotenv-expand": "^10.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "make-dir": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-          "dev": true,
-          "requires": {
-            "semver": "^6.0.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-              "dev": true
-            }
-          }
-        },
-        "minipass": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.1.tgz",
-          "integrity": "sha512-UZ7eQ+h8ywIRAW1hIEl2AqdwzJucU/Kp59+8kkZeSvafXhZjul247BvIJjEVFVeON6d7lM46XX1HXCduKAS8VA==",
-          "dev": true
-        },
-        "optionator": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-          "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-          "dev": true,
-          "requires": {
-            "deep-is": "^0.1.3",
-            "fast-levenshtein": "^2.0.6",
-            "levn": "^0.4.1",
-            "prelude-ls": "^1.2.1",
-            "type-check": "^0.4.0",
-            "word-wrap": "^1.2.3"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "ramda": {
-          "version": "0.29.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
-          "integrity": "sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-          "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "tempy": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
-          "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
-          "dev": true,
-          "requires": {
-            "del": "^6.0.0",
-            "is-stream": "^2.0.0",
-            "temp-dir": "^2.0.0",
-            "type-fest": "^0.16.0",
-            "unique-string": "^2.0.0"
-          },
-          "dependencies": {
-            "type-fest": {
-              "version": "0.16.0",
-              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
-              "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
-              "dev": true
-            }
-          }
-        },
-        "util": {
-          "version": "0.12.5",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-          "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "which-typed-array": "^1.1.2"
-          }
-        }
-      }
     },
     "@csstools/normalize.css": {
       "version": "12.0.0",
@@ -43647,10 +43182,473 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
+    "ecl-builder": {
+      "version": "file:packages/ecl-builder",
+      "requires": {
+        "@babel/core": "^7.18.10",
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+        "@babel/preset-env": "^7.18.10",
+        "@babel/preset-typescript": "^7.18.6",
+        "@emotion/react": "^11.9.3",
+        "@emotion/styled": "^11.9.3",
+        "@mui/icons-material": "^5.8.4",
+        "@mui/material": "^5.8.6",
+        "@storybook/addon-actions": "^8.0.10",
+        "@storybook/addon-essentials": "^8.0.10",
+        "@storybook/addon-interactions": "^8.0.10",
+        "@storybook/addon-links": "^8.0.10",
+        "@storybook/addon-webpack5-compiler-swc": "^1.0.2",
+        "@storybook/core-common": "^8.0.10",
+        "@storybook/csf-tools": "^8.0.10",
+        "@storybook/react": "^8.0.10",
+        "@storybook/react-webpack5": "^8.0.10",
+        "@storybook/test": "^8.0.10",
+        "@tanstack/react-query": "^4.2.1",
+        "@types/antlr4": "^4.7.2",
+        "@types/fhir": "^0.0.35",
+        "@types/jest": "^28.1.7",
+        "@types/react": "^18.0.12",
+        "@types/react-copy-to-clipboard": "^5.0.4",
+        "@types/uuid": "^8.3.4",
+        "@typescript-eslint/eslint-plugin": "^5.33.1",
+        "@typescript-eslint/parser": "^5.33.1",
+        "antlr4": "~4.10.1",
+        "babel-jest": "^28.1.3",
+        "babel-loader": "^8.2.5",
+        "eslint": "^8.22.0",
+        "eslint-plugin-react": "^7.30.1",
+        "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-storybook": "^0.8.0",
+        "fix-tsc-es-imports": "^0.1.6",
+        "glob": "^10.3.14",
+        "jest": "^28.1.3",
+        "magicast": "^0.3.4",
+        "react": "^17.0.2",
+        "react-copy-to-clipboard": "^5.1.0",
+        "react-dom": "^17.0.2",
+        "storybook": "^8.0.10",
+        "typescript": "^4.7.3",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@storybook/core-common": {
+          "version": "8.0.10",
+          "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-8.0.10.tgz",
+          "integrity": "sha512-hsFlPieputaDQoxstnPa3pykTc4bUwEDgCHf8U43+/Z7qmLOQ9fpG+2CFW930rsCRghYpPreOvsmhY7lsGKWLQ==",
+          "dev": true,
+          "requires": {
+            "@storybook/core-events": "8.0.10",
+            "@storybook/csf-tools": "8.0.10",
+            "@storybook/node-logger": "8.0.10",
+            "@storybook/types": "8.0.10",
+            "@yarnpkg/fslib": "2.10.3",
+            "@yarnpkg/libzip": "2.3.0",
+            "chalk": "^4.1.0",
+            "cross-spawn": "^7.0.3",
+            "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
+            "esbuild-register": "^3.5.0",
+            "execa": "^5.0.0",
+            "file-system-cache": "2.3.0",
+            "find-cache-dir": "^3.0.0",
+            "find-up": "^5.0.0",
+            "fs-extra": "^11.1.0",
+            "glob": "^10.0.0",
+            "handlebars": "^4.7.7",
+            "lazy-universal-dotenv": "^4.0.0",
+            "node-fetch": "^2.0.0",
+            "picomatch": "^2.3.0",
+            "pkg-dir": "^5.0.0",
+            "pretty-hrtime": "^1.0.3",
+            "resolve-from": "^5.0.0",
+            "semver": "^7.3.7",
+            "tempy": "^1.0.1",
+            "tiny-invariant": "^1.3.1",
+            "ts-dedent": "^2.0.0",
+            "util": "^0.12.4"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "8.0.10",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.0.10.tgz",
+          "integrity": "sha512-TuHPS6p5ZNr4vp4butLb4R98aFx0NRYCI/7VPhJEUH5rPiqNzE3PZd8DC8rnVxavsJ+jO1/y+egNKXRYkEcoPQ==",
+          "dev": true,
+          "requires": {
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/node-logger": {
+          "version": "8.0.10",
+          "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.0.10.tgz",
+          "integrity": "sha512-UMmaUaA3VOX/mKLsSvOnbZre2/1tZ6hazA6H0eAnClKb51jRD1AJrsBYK+uHr/CAp7t710bB5U8apPov7hayDw==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "dotenv": {
+          "version": "16.4.5",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+          "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+          "dev": true
+        },
+        "dotenv-expand": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+          "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+          "dev": true
+        },
+        "eslint": {
+          "version": "8.22.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.22.0.tgz",
+          "integrity": "sha512-ci4t0sz6vSRKdmkOGmprBo6fmI4PrphDFMy5JEq/fNS0gQkJM3rLmrqcp8ipMcdobH3KtUP40KniAE9W19S4wA==",
+          "dev": true,
+          "requires": {
+            "@eslint/eslintrc": "^1.3.0",
+            "@humanwhocodes/config-array": "^0.10.4",
+            "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+            "ajv": "^6.10.0",
+            "chalk": "^4.0.0",
+            "cross-spawn": "^7.0.2",
+            "debug": "^4.3.2",
+            "doctrine": "^3.0.0",
+            "escape-string-regexp": "^4.0.0",
+            "eslint-scope": "^7.1.1",
+            "eslint-utils": "^3.0.0",
+            "eslint-visitor-keys": "^3.3.0",
+            "espree": "^9.3.3",
+            "esquery": "^1.4.0",
+            "esutils": "^2.0.2",
+            "fast-deep-equal": "^3.1.3",
+            "file-entry-cache": "^6.0.1",
+            "find-up": "^5.0.0",
+            "functional-red-black-tree": "^1.0.1",
+            "glob-parent": "^6.0.1",
+            "globals": "^13.15.0",
+            "globby": "^11.1.0",
+            "grapheme-splitter": "^1.0.4",
+            "ignore": "^5.2.0",
+            "import-fresh": "^3.0.0",
+            "imurmurhash": "^0.1.4",
+            "is-glob": "^4.0.0",
+            "js-yaml": "^4.1.0",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.4.1",
+            "lodash.merge": "^4.6.2",
+            "minimatch": "^3.1.2",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.9.1",
+            "regexpp": "^3.2.0",
+            "strip-ansi": "^6.0.1",
+            "strip-json-comments": "^3.1.0",
+            "text-table": "^0.2.0",
+            "v8-compile-cache": "^2.0.3"
+          }
+        },
+        "eslint-scope": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+          "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^5.2.0"
+          }
+        },
+        "file-system-cache": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/file-system-cache/-/file-system-cache-2.3.0.tgz",
+          "integrity": "sha512-l4DMNdsIPsVnKrgEXbJwDJsA5mB8rGwHYERMgqQx/xAUtChPJMre1bXBzDEqqVbWv9AIbFezXMxeEkZDSrXUOQ==",
+          "dev": true,
+          "requires": {
+            "fs-extra": "11.1.1",
+            "ramda": "0.29.0"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "11.1.1",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+              "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+              }
+            }
+          }
+        },
+        "find-cache-dir": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+          "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^3.0.2",
+            "pkg-dir": "^4.1.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+              }
+            },
+            "pkg-dir": {
+              "version": "4.2.0",
+              "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+              "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+              "dev": true,
+              "requires": {
+                "find-up": "^4.0.0"
+              }
+            }
+          }
+        },
+        "fs-extra": {
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "glob": {
+          "version": "10.3.14",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.14.tgz",
+          "integrity": "sha512-4fkAqu93xe9Mk7le9v0y3VrPDqLKHarNi2s4Pv7f2yOvfhWfhc7hRPHC/JyqMqb8B/Dt/eGS4n7ykwf3fOsl8g==",
+          "dev": true,
+          "requires": {
+            "foreground-child": "^3.1.0",
+            "jackspeak": "^2.3.6",
+            "minimatch": "^9.0.1",
+            "minipass": "^7.0.4",
+            "path-scurry": "^1.11.0"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "9.0.4",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+              "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^2.0.1"
+              }
+            }
+          }
+        },
+        "globals": {
+          "version": "13.17.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+          "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "lazy-universal-dotenv": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/lazy-universal-dotenv/-/lazy-universal-dotenv-4.0.0.tgz",
+          "integrity": "sha512-aXpZJRnTkpK6gQ/z4nk+ZBLd/Qdp118cvPruLSIQzQNRhKwEcdXCOzXuF55VDqIiuAaY3UGZ10DJtvZzDcvsxg==",
+          "dev": true,
+          "requires": {
+            "app-root-dir": "^1.0.2",
+            "dotenv": "^16.0.0",
+            "dotenv-expand": "^10.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+              "dev": true
+            }
+          }
+        },
+        "minipass": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.1.tgz",
+          "integrity": "sha512-UZ7eQ+h8ywIRAW1hIEl2AqdwzJucU/Kp59+8kkZeSvafXhZjul247BvIJjEVFVeON6d7lM46XX1HXCduKAS8VA==",
+          "dev": true
+        },
+        "optionator": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+          "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+          "dev": true,
+          "requires": {
+            "deep-is": "^0.1.3",
+            "fast-levenshtein": "^2.0.6",
+            "levn": "^0.4.1",
+            "prelude-ls": "^1.2.1",
+            "type-check": "^0.4.0",
+            "word-wrap": "^1.2.3"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "ramda": {
+          "version": "0.29.0",
+          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
+          "integrity": "sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+          "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "tempy": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
+          "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
+          "dev": true,
+          "requires": {
+            "del": "^6.0.0",
+            "is-stream": "^2.0.0",
+            "temp-dir": "^2.0.0",
+            "type-fest": "^0.16.0",
+            "unique-string": "^2.0.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.16.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+              "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+              "dev": true
+            }
+          }
+        },
+        "util": {
+          "version": "0.12.5",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+          "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "which-typed-array": "^1.1.2"
+          }
+        }
+      }
+    },
     "ecl-builder-app": {
       "version": "file:apps/ecl-builder-app",
       "requires": {
-        "@csiro/ecl-builder": "^0.2.1",
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",
         "@mui/icons-material": "^5.8.3",
@@ -43658,6 +43656,7 @@
         "@types/node": "^16.11.56",
         "@types/react": "^17.0.2",
         "@types/react-dom": "^17.0.2",
+        "ecl-builder": "^0.2.1",
         "eslint": "^8.23.0",
         "eslint-plugin-react": "^7.31.1",
         "react": "^17.0.2",

--- a/packages/ecl-builder/package.json
+++ b/packages/ecl-builder/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@csiro/ecl-builder",
+  "name": "ecl-builder",
   "version": "0.2.1",
   "description": "UI components that help you build SNOMED CT ECL expressions",
   "main": "lib/index.js",


### PR DESCRIPTION
The .npmrc should no longer be needed, think it was causing the auth issues as it had always-auth=true.

Do you have the rights to publish to @csiro scope on npm? Probably do because I see other packages on there with it, like @csiro/shrimp-hierarchy-view. Worth asking anyways.